### PR TITLE
Fix broken unit tests

### DIFF
--- a/tests/unit/experimental-utils.test.ts
+++ b/tests/unit/experimental-utils.test.ts
@@ -2,15 +2,11 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { getInferredInterests } from "../../src/tools/experimental-utils.js";
 
 // Mock the generated API module
-vi.mock("../../src/generated/gravatar-api/index.js", () => {
+vi.mock("../../src/generated/clients/index.js", () => {
   const mockGetProfileInferredInterestsById = vi.fn();
-  const mockConfiguration = vi.fn();
 
   return {
-    ExperimentalApi: vi.fn(() => ({
-      getProfileInferredInterestsById: mockGetProfileInferredInterestsById,
-    })),
-    Configuration: mockConfiguration,
+    getProfileInferredInterestsById: mockGetProfileInferredInterestsById,
   };
 });
 
@@ -52,27 +48,26 @@ describe("Experimental Utils", () => {
     ];
 
     it("should return interests data on successful API call", async () => {
-      const { ExperimentalApi } = await import("../../src/generated/gravatar-api/index.js");
+      const { getProfileInferredInterestsById } = await import(
+        "../../src/generated/clients/index.js"
+      );
 
-      const mockInstance = new (ExperimentalApi as any)();
-      const mockGetProfileInferredInterestsById = mockInstance.getProfileInferredInterestsById;
-
-      mockGetProfileInferredInterestsById.mockResolvedValue(mockInterestsData);
+      (getProfileInferredInterestsById as any).mockResolvedValue(mockInterestsData);
 
       const result = await getInferredInterests(testIdentifier);
 
-      expect(mockGetProfileInferredInterestsById).toHaveBeenCalledWith({
-        profileIdentifier: testIdentifier,
-      });
+      expect(getProfileInferredInterestsById).toHaveBeenCalledWith(
+        testIdentifier,
+        expect.any(Object),
+      );
       expect(result).toEqual(mockInterestsData);
     });
 
     it("should handle HTTP errors", async () => {
-      const { ExperimentalApi } = await import("../../src/generated/gravatar-api/index.js");
+      const { getProfileInferredInterestsById } = await import(
+        "../../src/generated/clients/index.js"
+      );
       const { mapHttpError } = await import("../../src/common/utils.js");
-
-      const mockInstance = new (ExperimentalApi as any)();
-      const mockGetProfileInferredInterestsById = mockInstance.getProfileInferredInterestsById;
 
       const mockError = {
         response: {
@@ -82,7 +77,7 @@ describe("Experimental Utils", () => {
       };
       const mappedErrorMessage = "No profile found for identifier: test-profile-id";
 
-      mockGetProfileInferredInterestsById.mockRejectedValue(mockError);
+      (getProfileInferredInterestsById as any).mockRejectedValue(mockError);
       (mapHttpError as any).mockReturnValue(mappedErrorMessage);
 
       await expect(getInferredInterests(testIdentifier)).rejects.toThrow(mappedErrorMessage);
@@ -91,13 +86,12 @@ describe("Experimental Utils", () => {
     });
 
     it("should handle network errors", async () => {
-      const { ExperimentalApi } = await import("../../src/generated/gravatar-api/index.js");
-
-      const mockInstance = new (ExperimentalApi as any)();
-      const mockGetProfileInferredInterestsById = mockInstance.getProfileInferredInterestsById;
+      const { getProfileInferredInterestsById } = await import(
+        "../../src/generated/clients/index.js"
+      );
 
       const networkError = new Error("Network connection failed");
-      mockGetProfileInferredInterestsById.mockRejectedValue(networkError);
+      (getProfileInferredInterestsById as any).mockRejectedValue(networkError);
 
       await expect(getInferredInterests(testIdentifier)).rejects.toThrow(
         "Network error while fetching interests: Network connection failed",

--- a/tests/unit/profile-utils.test.ts
+++ b/tests/unit/profile-utils.test.ts
@@ -2,15 +2,11 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { getProfile } from "../../src/tools/profile-utils.js";
 
 // Mock the generated API module
-vi.mock("../../src/generated/gravatar-api/index.js", () => {
+vi.mock("../../src/generated/clients/index.js", () => {
   const mockGetProfileById = vi.fn();
-  const mockConfiguration = vi.fn();
 
   return {
-    ProfilesApi: vi.fn(() => ({
-      getProfileById: mockGetProfileById,
-    })),
-    Configuration: mockConfiguration,
+    getProfileById: mockGetProfileById,
   };
 });
 
@@ -49,27 +45,19 @@ describe("Profile Utils", () => {
     };
 
     it("should return profile data on successful API call", async () => {
-      const { ProfilesApi } = await import("../../src/generated/gravatar-api/index.js");
+      const { getProfileById } = await import("../../src/generated/clients/index.js");
 
-      const mockInstance = new (ProfilesApi as any)();
-      const mockGetProfileById = mockInstance.getProfileById;
-
-      mockGetProfileById.mockResolvedValue(mockProfileData);
+      (getProfileById as any).mockResolvedValue(mockProfileData);
 
       const result = await getProfile(testIdentifier);
 
-      expect(mockGetProfileById).toHaveBeenCalledWith({
-        profileIdentifier: testIdentifier,
-      });
+      expect(getProfileById).toHaveBeenCalledWith(testIdentifier, expect.any(Object));
       expect(result).toEqual(mockProfileData);
     });
 
     it("should handle HTTP errors", async () => {
-      const { ProfilesApi } = await import("../../src/generated/gravatar-api/index.js");
+      const { getProfileById } = await import("../../src/generated/clients/index.js");
       const { mapHttpError } = await import("../../src/common/utils.js");
-
-      const mockInstance = new (ProfilesApi as any)();
-      const mockGetProfileById = mockInstance.getProfileById;
 
       const mockError = {
         response: {
@@ -79,7 +67,7 @@ describe("Profile Utils", () => {
       };
       const mappedErrorMessage = "No profile found for identifier: test-profile-id";
 
-      mockGetProfileById.mockRejectedValue(mockError);
+      (getProfileById as any).mockRejectedValue(mockError);
       (mapHttpError as any).mockReturnValue(mappedErrorMessage);
 
       await expect(getProfile(testIdentifier)).rejects.toThrow(mappedErrorMessage);
@@ -88,13 +76,10 @@ describe("Profile Utils", () => {
     });
 
     it("should handle network errors", async () => {
-      const { ProfilesApi } = await import("../../src/generated/gravatar-api/index.js");
-
-      const mockInstance = new (ProfilesApi as any)();
-      const mockGetProfileById = mockInstance.getProfileById;
+      const { getProfileById } = await import("../../src/generated/clients/index.js");
 
       const networkError = new Error("Network connection failed");
-      mockGetProfileById.mockRejectedValue(networkError);
+      (getProfileById as any).mockRejectedValue(networkError);
 
       await expect(getProfile(testIdentifier)).rejects.toThrow(
         "Network error while fetching profile: Network connection failed",


### PR DESCRIPTION
## Summary
- Fixed unit tests for profile-utils and experimental-utils that were failing due to incorrect mocking
- Updated mock paths from `gravatar-api/index.js` to `clients/index.js` to match actual implementation
- Changed from class-based API mocking to functional export mocking to align with generated client structure
- Fixed function call expectations to match actual implementation signature

## Test plan
- [x] All 80 tests now pass
- [x] Linting passes
- [x] Type checking passes

🤖 Generated with [Claude Code](https://claude.ai/code)