### PR TITLE
Add deploy environments and standardize deployment commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,10 @@
 	"version": "0.1.0",
 	"private": true,
 	"scripts": {
-		"deploy": "wrangler deploy",
+		"deploy": "wrangler deploy --env production",
+		"deploy:staging": "wrangler deploy --env staging",
 		"dev": "wrangler dev",
+		"dev:staging": "wrangler dev --env staging",
 		"format": "biome format --write",
 		"lint": "biome lint",
 		"lint:fix": "biome lint --fix",

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -28,6 +28,39 @@
 	},
 	"observability": {
 		"enabled": true
+	},
+	"vars": {
+		"ENVIRONMENT": "development"
+	},
+	"env": {
+		"staging": {
+			"name": "mcp-server-gravatar-remote-staging",
+			"durable_objects": {
+				"bindings": [
+					{
+						"class_name": "GravatarMcpServer",
+						"name": "MCP_OBJECT"
+					}
+				]
+			},
+			"vars": {
+				"ENVIRONMENT": "staging"
+			}
+		},
+		"production": {
+			"name": "mcp-server-gravatar-remote-production",
+			"durable_objects": {
+				"bindings": [
+					{
+						"class_name": "GravatarMcpServer",
+						"name": "MCP_OBJECT"
+					}
+				]
+			},
+			"vars": {
+				"ENVIRONMENT": "production"
+			}
+		}
 	}
 	/**
 	 * Smart Placement


### PR DESCRIPTION
## Summary
• Add support for staging and production deployment environments
• Standardize deployment commands with `npm run deploy` targeting production
• Add environment-specific configurations in wrangler.jsonc
• Include staging development server command

## Changes Made
• Updated `deploy` script to deploy to production environment
• Added `deploy:staging` script for staging deployments  
• Added `dev:staging` script for staging development server
• Configured distinct staging and production environments in wrangler.jsonc with separate worker names and environment variables

## Test plan
- [x] Verify `npm run deploy` deploys to production environment
- [x] Verify deployment scripts work correctly with distinct environments
- [x] Confirm wrangler configuration is valid for both environments

🤖 Generated with [Claude Code](https://claude.ai/code)