### PR TITLE
Make server name configurable per environment

### DIFF
--- a/src/common/env.ts
+++ b/src/common/env.ts
@@ -1,0 +1,11 @@
+import { env } from "cloudflare:workers";
+
+// Helper to cast env as any generic Env type
+export function getEnv<Env>() {
+  return env as Env;
+}
+
+export interface Env {
+  ENVIRONMENT: "development" | "staging" | "production";
+  MCP_SERVER_NAME: string;
+}

--- a/src/config/server-config.ts
+++ b/src/config/server-config.ts
@@ -3,7 +3,10 @@
  * Adapted for Cloudflare Workers environment
  */
 
+import { getEnv, type Env } from "../common/env.js";
 import { VERSION } from "../common/version.js";
+
+const env = getEnv<Env>();
 
 /**
  * Server configuration object
@@ -15,7 +18,7 @@ export const config = {
   restApiBase: "https://api.gravatar.com/v3",
 
   // User agent for API requests
-  userAgent: `Remote-Gravatar-MCP-Server/${VERSION}`,
+  userAgent: `${env.MCP_SERVER_NAME}/${VERSION}`,
 
   // Request timeout (in milliseconds)
   requestTimeout: 30000,
@@ -26,7 +29,7 @@ export const config = {
  */
 export function getServerInfo() {
   return {
-    name: "Gravatar MCP Server",
+    name: `${env.MCP_SERVER_NAME}`,
     version: VERSION,
   };
 }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -4,7 +4,7 @@
  */
 {
 	"$schema": "node_modules/wrangler/config-schema.json",
-	"name": "mcp-server-gravatar-remote",
+	"name": "mcp-server-gravatar",
 	"main": "src/index.ts",
 	"compatibility_date": "2025-03-10",
 	"compatibility_flags": [
@@ -29,12 +29,21 @@
 	"observability": {
 		"enabled": true
 	},
+	/**
+	 * Environment Variables
+	 * https://developers.cloudflare.com/workers/wrangler/configuration/#environment-variables
+	 */
+	/**
+	 * Note: Use secrets to store sensitive data.
+	 * https://developers.cloudflare.com/workers/configuration/secrets/
+	 */
 	"vars": {
-		"ENVIRONMENT": "development"
+		"ENVIRONMENT": "development",
+		"MCP_SERVER_NAME": "mcp-server-gravatar-development"
 	},
 	"env": {
 		"staging": {
-			"name": "mcp-server-gravatar-remote-staging",
+			"name": "mcp-server-gravatar-staging",
 			"durable_objects": {
 				"bindings": [
 					{
@@ -44,11 +53,12 @@
 				]
 			},
 			"vars": {
-				"ENVIRONMENT": "staging"
+				"ENVIRONMENT": "staging",
+				"MCP_SERVER_NAME": "mcp-server-gravatar-staging"
 			}
 		},
 		"production": {
-			"name": "mcp-server-gravatar-remote-production",
+			"name": "mcp-server-gravatar-production",
 			"durable_objects": {
 				"bindings": [
 					{
@@ -58,10 +68,17 @@
 				]
 			},
 			"vars": {
-				"ENVIRONMENT": "production"
+				"ENVIRONMENT": "production",
+				"MCP_SERVER_NAME": "mcp-server-gravatar"
 			}
 		}
 	},
+	/**
+	 * Static Assets
+	 * https://developers.cloudflare.com/workers/static-assets/binding/
+	 */
+	"assets": { "directory": "./assets/", "binding": "ASSETS" }
+
 	/**
 	 * Smart Placement
 	 * Docs: https://developers.cloudflare.com/workers/configuration/smart-placement/#smart-placement
@@ -74,22 +91,6 @@
 	 * databases, object storage, AI inference, real-time communication and more.
 	 * https://developers.cloudflare.com/workers/runtime-apis/bindings/
 	 */
-
-	/**
-	 * Environment Variables
-	 * https://developers.cloudflare.com/workers/wrangler/configuration/#environment-variables
-	 */
-	// "vars": { "MY_VARIABLE": "production_value" },
-	/**
-	 * Note: Use secrets to store sensitive data.
-	 * https://developers.cloudflare.com/workers/configuration/secrets/
-	 */
-
-	/**
-	 * Static Assets
-	 * https://developers.cloudflare.com/workers/static-assets/binding/
-	 */
-	"assets": { "directory": "./assets/", "binding": "ASSETS" }
 
 	/**
 	 * Service Bindings (communicate between multiple Workers)


### PR DESCRIPTION
  - Add MCP_SERVER_NAME environment variable with descriptive names for each environment
  - Update server configuration to use dynamic server name from environment variables
  - Improve user agent string to reflect actual server name instead of hardcoded value
  - Clean up wrangler.JSONC configuration and remove -remote suffix