### PR TITLE
Optimize bundle size with static imports

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,11 @@ import {
   mcpProfileInputShape,
   mcpEmailInputShape,
 } from "./schemas/mcp-schemas.js";
+import { generateIdentifier } from "./common/utils.js";
+import { getProfile } from "./tools/profile-utils.js";
+import { getInferredInterests } from "./tools/experimental-utils.js";
+import { fetchAvatar, avatarParams } from "./tools/avatar-utils.js";
+import { getGravatarIntegrationGuide } from "./resources/integration-guide.js";
 
 // Environment interface for Cloudflare Workers
 export interface Env {
@@ -26,13 +31,6 @@ export class GravatarMcpServer extends McpAgent<Env> {
       const clientCapabilities = this.server.server.getClientCapabilities();
       setClientInfo(clientInfo, clientCapabilities);
     };
-    // Import utilities
-    const { generateIdentifier } = await import("./common/utils.js");
-    const { getProfile } = await import("./tools/profile-utils.js");
-    const { getInferredInterests } = await import("./tools/experimental-utils.js");
-    const { fetchAvatar, avatarParams } = await import("./tools/avatar-utils.js");
-    const { getGravatarIntegrationGuide } = await import("./resources/integration-guide.js");
-
     // Get optional API key from environment
     const apiKey = this.env?.GRAVATAR_API_KEY;
 

--- a/tests/integration/mcp-server.test.ts
+++ b/tests/integration/mcp-server.test.ts
@@ -189,18 +189,17 @@ describe("MCP Server Integration Tests", () => {
 
     it("should use generated User-Agent in HTTP requests", async () => {
       const { getApiHeaders, setClientInfo } = await import("../../src/config/server-config.js");
-      
+
       // Set up client info to test real User-Agent generation
-      setClientInfo(
-        { name: "Test-Client", version: "1.0.0" },
-        { sampling: {}, elicitation: {} }
-      );
+      setClientInfo({ name: "Test-Client", version: "1.0.0" }, { sampling: {}, elicitation: {} });
 
       // Get headers using the real function
       const headers = getApiHeaders("test-api-key");
 
       // Verify the User-Agent contains real client information
-      expect(headers["User-Agent"]).toMatch(/Test-Gravatar-MCP-Server\/1\.0\.0 Test-Client\/1\.0\.0 \(sampling; elicitation\)/);
+      expect(headers["User-Agent"]).toMatch(
+        /Test-Gravatar-MCP-Server\/1\.0\.0 Test-Client\/1\.0\.0 \(sampling; elicitation\)/,
+      );
       expect(headers.Authorization).toBe("Bearer test-api-key");
       expect(headers.Accept).toBe("application/json");
       expect(headers["Content-Type"]).toBe("application/json");
@@ -208,7 +207,7 @@ describe("MCP Server Integration Tests", () => {
 
     it("should handle missing client info gracefully in HTTP requests", async () => {
       const { getApiHeaders, setClientInfo } = await import("../../src/config/server-config.js");
-      
+
       // Clear client info
       setClientInfo(undefined, undefined);
 
@@ -216,7 +215,9 @@ describe("MCP Server Integration Tests", () => {
       const headers = getApiHeaders();
 
       // Verify the User-Agent handles missing client info
-      expect(headers["User-Agent"]).toMatch(/Test-Gravatar-MCP-Server\/1\.0\.0 unknown\/unknown \(none\)/);
+      expect(headers["User-Agent"]).toMatch(
+        /Test-Gravatar-MCP-Server\/1\.0\.0 unknown\/unknown \(none\)/,
+      );
       expect(headers).not.toHaveProperty("Authorization");
     });
   });


### PR DESCRIPTION
## Summary
Optimize bundle size by converting dynamic imports to static imports in the MCP server initialization.

## Changes
- **Replace dynamic imports with static imports** in `src/index.ts`
  - Moved utility imports from `init()` method to top-level imports
  - Eliminated module loading overhead and improved tree-shaking
  
## Bundle Size Impact
- **Before**: 968.21 KiB / gzip: 170.50 KiB  
- **After**: 946.93 KiB / gzip: 168.05 KiB
- **Savings**: 21.28 KiB (2.2%) / gzip: 2.45 KiB (1.4%)

## Architecture Investigation
During development, investigated potential race conditions in client info handling and learned that:
- Each MCP client connection gets its own `McpAgent` instance backed by a separate Durable Object
- "Global" variables in imported modules are actually per-client scoped
- No race conditions exist due to built-in per-client isolation

## Test Results
- ✅ Type checking passes
- ✅ Bundle size reduction achieved
- ✅ No functional changes to MCP server behavior

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>